### PR TITLE
Fix Context Manager path in plugin.py

### DIFF
--- a/Context Manager.glyphsPlugin/Contents/Resources/plugin.py
+++ b/Context Manager.glyphsPlugin/Contents/Resources/plugin.py
@@ -40,7 +40,7 @@ class contextManager(GeneralPlugin):
 		if not os.path.exists(self.jsonPath):
 			try:
 				import shutil
-				path = os.path.expanduser("~/Library/Application Support/Glyphs 3/Repositories/ContextManager/Context Manager.glyphsPlugin/Contents/Resources/ContextManager.json")
+				path = os.path.expanduser("~/Library/Application Support/Glyphs 3/Repositories/Context-Manager/Context Manager.glyphsPlugin/Contents/Resources/ContextManager.json")
 				shutil.copy(path, os.path.expanduser("~/Library/Application Support/Glyphs 3/info"))
 			except:
 				with open('ContextManager.json', 'w') as f:


### PR DESCRIPTION
The path has a dash in it when installed from Plugin Manager.
Should solve https://github.com/HugoJourdan/Context-Manager/issues/1 although a user will have to delete `~/Library/Application Support/Glyphs 3/info` to get the file to copy correctly.